### PR TITLE
Fix invalid license in META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -4,7 +4,7 @@
     "version"     : "*",
     "description" : "Dictionaries creating module",
     "depends"     : [ ],
-    "license":    "Apache-License-2.0",
+    "license":    "Apache-2.0",
     "provides"    : {
         "Dictionary::Create"            : "lib/Dictionary/Create.pm",
         "Dictionary::Create::DSL"   : "lib/Dictionary/Create/DSL.pm"


### PR DESCRIPTION
The license field should be a valid SPDX identifier as mentioned under https://docs.raku.org/language/modules#Preparing_the_module